### PR TITLE
Fix ST_ValueCount coverage crash on empty table

### DIFF
--- a/raster/rt_pg/rtpg_statistics.c
+++ b/raster/rt_pg/rtpg_statistics.c
@@ -2073,8 +2073,9 @@ Datum RASTER_valueCountCoverage(PG_FUNCTION_ARGS) {
 	}
 	/* do when there is no more left */
 	else {
-		pfree(covvcnts2);
-		SRF_RETURN_DONE(funcctx);
-	}
+               if (covvcnts2)
+                       pfree(covvcnts2);
+               SRF_RETURN_DONE(funcctx);
+       }
 }
 


### PR DESCRIPTION
## Summary
- avoid calling `pfree` on a NULL pointer in `RASTER_valueCountCoverage`

## Testing
- `make check` *(fails: "You need to run the 'configure' program first. See the file 'README.postgis' for installation instructions")*
- `./autogen.sh` *(fails: `Missing autoconf!`)*