### PR TITLE
Inline histogram helper utilities

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,10 @@ xxxx/xx/xx
  - #5702, Allow the compiler to detect the parallelism -flto=auto (Darafei Praliaskouski)
  - #4798, ST_AsGeoJSON warns about duplicate property keys (Darafei Praliaskouski)
 
+* Bug Fixes *
+
+ - #5959, Prevent histogram target overflow when analysing massive tables (Darafei Praliaskouski)
+
 
 PostGIS 3.6.0
 2025/09/01

--- a/configure.ac
+++ b/configure.ac
@@ -1938,6 +1938,7 @@ AC_CONFIG_FILES([GNUmakefile
    libpgcommon/Makefile
    libpgcommon/cunit/Makefile
    postgis/Makefile
+   postgis/cunit/Makefile
    postgis/sqldefines.h
    sfcgal/Makefile
    $SFCGAL_MAKEFILE_LIST

--- a/postgis/cunit/Makefile.in
+++ b/postgis/cunit/Makefile.in
@@ -1,0 +1,43 @@
+# **********************************************************************
+# *
+# * PostGIS - Spatial Types for PostgreSQL
+# * http://postgis.net
+# *
+# * Copyright 2025 Darafei Praliaskouski <me@komzpa.net>
+# *
+# * This is free software; you can redistribute and/or modify it under
+# * the terms of the GNU General Public Licence. See the COPYING file.
+# *
+# **********************************************************************
+
+srcdir = @srcdir@
+top_builddir = @top_builddir@
+
+CC=@CC@
+LIBTOOL=@LIBTOOL@
+CFLAGS = @CFLAGS@ @CPPFLAGS@ @PGSQL_BE_CPPFLAGS@ @CUNIT_CPPFLAGS@ -I.. -I$(top_builddir) -I@top_srcdir@/liblwgeom -I@top_builddir@/liblwgeom -I@top_srcdir@/libpgcommon -I@top_builddir@/libpgcommon
+LDFLAGS = @CUNIT_LDFLAGS@ -lm
+
+VPATH = $(srcdir)
+
+OBJS = cu_tester.o
+
+# Build the standalone histogram helper tester.
+all: cu_tester
+
+# Execute the suite directly; no installation step is required.
+check: all
+	$(LIBTOOL) --mode=execute ./cu_tester
+
+# Link the tester with libtool; all helper code is header-only.
+cu_tester: $(OBJS)
+	$(LIBTOOL) --mode=link $(CC) $(CFLAGS) -o $@ $(OBJS) $(LDFLAGS)
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+clean:
+	rm -f $(OBJS) cu_tester
+
+clobber distclean: clean
+	rm -f Makefile

--- a/postgis/cunit/cu_tester.c
+++ b/postgis/cunit/cu_tester.c
@@ -1,0 +1,154 @@
+/**********************************************************************
+ *
+ * PostGIS - Spatial Types for PostgreSQL
+ * http://postgis.net
+ *
+ * This file is part of PostGIS
+ *
+ * PostGIS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * PostGIS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PostGIS.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **********************************************************************
+ *
+ * Copyright 2025 (C) Darafei Praliaskouski <me@komzpa.net>
+ *
+ **********************************************************************/
+
+#include "postgres.h"
+
+#include <CUnit/Basic.h>
+#include <limits.h>
+#include <string.h>
+
+#include "../gserialized_estimate_support.h"
+
+static ND_BOX
+make_box(float minx, float miny, float minz, float minm, float maxx, float maxy, float maxz, float maxm)
+{
+	ND_BOX box;
+
+	memset(&box, 0, sizeof(box));
+	box.min[0] = minx;
+	box.min[1] = miny;
+	box.min[2] = minz;
+	box.min[3] = minm;
+	box.max[0] = maxx;
+	box.max[1] = maxy;
+	box.max[2] = maxz;
+	box.max[3] = maxm;
+	return box;
+}
+
+static void
+histogram_budget_clamps(void)
+{
+	/* Zero or negative row counts disable histogram construction. */
+	CU_ASSERT_EQUAL(histogram_cell_budget(0.0, 2, 100), 0);
+	CU_ASSERT_EQUAL(histogram_cell_budget(-1.0, 4, 100), 0);
+
+	/* Degenerate dimensionality cannot allocate histogram space. */
+	CU_ASSERT_EQUAL(histogram_cell_budget(1000.0, 0, 100), 0);
+
+	/* Matches the classic pow(attstattarget, ndims) path. */
+	CU_ASSERT_EQUAL(histogram_cell_budget(1e6, 2, 100), 10000);
+	CU_ASSERT_EQUAL(histogram_cell_budget(1e6, 3, 50), 125000);
+
+	/* attstattarget^ndims exceeds ndims * 100000 and must be clamped. */
+	CU_ASSERT_EQUAL(histogram_cell_budget(1e6, 4, 50), 400000);
+
+	/* attstattarget<=0 is normalised to the smallest viable target. */
+	CU_ASSERT_EQUAL(histogram_cell_budget(1e6, 2, 0), 1);
+
+	/* Row clamp shrinks the grid for small relations. */
+	CU_ASSERT_EQUAL(histogram_cell_budget(1.0, 2, 100), 20);
+
+	/* Large tables now preserve the dimensional cap instead of overflowing. */
+	CU_ASSERT_EQUAL(histogram_cell_budget(1.5e8, 2, 100), 10000);
+
+	/* Regression for #5984: huge attstat targets stabilise instead of wrapping. */
+	CU_ASSERT_EQUAL(histogram_cell_budget(5e6, 2, 10000), 200000);
+
+	/* Trigger the INT_MAX guard once both other caps exceed it. */
+	CU_ASSERT_EQUAL(histogram_cell_budget((double)INT_MAX, 50000, INT_MAX), INT_MAX);
+}
+
+static void
+nd_stats_indexing_behaviour(void)
+{
+	ND_STATS stats;
+	const int good_index[ND_DIMS] = {1, 2, 0, 0};
+	const int bad_index[ND_DIMS] = {1, 5, 0, 0};
+
+	memset(&stats, 0, sizeof(stats));
+	stats.ndims = 3;
+	stats.size[0] = 4.0f;
+	stats.size[1] = 5.0f;
+	stats.size[2] = 3.0f;
+
+	/* Three-dimensional index  (x=1, y=2, z=0) collapses into 1 + 2 * 4. */
+	CU_ASSERT_EQUAL(nd_stats_value_index(&stats, good_index), 1 + 2 * 4);
+	/* Any request outside the histogram bounds triggers a guard. */
+	CU_ASSERT_EQUAL(nd_stats_value_index(&stats, bad_index), -1);
+
+	/* Regression for #5959: ndims higher than populated sizes still honours guards. */
+	stats.ndims = 4;
+	CU_ASSERT_EQUAL(nd_stats_value_index(&stats, good_index), -1);
+}
+
+static void
+nd_box_ratio_cases(void)
+{
+	ND_BOX covering = make_box(0.0f, 0.0f, 0.0f, 0.0f, 2.0f, 2.0f, 2.0f, 0.0f);
+	ND_BOX interior = make_box(0.5f, 0.5f, 0.5f, 0.0f, 1.5f, 1.5f, 1.5f, 0.0f);
+	ND_BOX partial = make_box(0.0f, 0.0f, 0.0f, 0.0f, 0.5f, 0.5f, 0.5f, 0.0f);
+	ND_BOX target = make_box(0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 0.0f);
+	ND_BOX flat = make_box(0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0.0f);
+	ND_BOX touch = make_box(2.0f, 0.0f, 0.0f, 0.0f, 3.0f, 1.0f, 1.0f, 0.0f);
+
+	/* Full coverage should evaluate to one regardless of the extra extent. */
+	CU_ASSERT_DOUBLE_EQUAL(nd_box_ratio(&covering, &interior, 3), 1.0, 1e-12);
+	/* A shared octant carries one eighth of the reference volume. */
+	CU_ASSERT_DOUBLE_EQUAL(nd_box_ratio(&partial, &target, 3), 0.125, 1e-12);
+	/* Degenerate slabs have zero volume in three dimensions. */
+	CU_ASSERT_DOUBLE_EQUAL(nd_box_ratio(&covering, &flat, 3), 0.0, 1e-12);
+	/* Boxes that only touch along a face should not count as overlap. */
+	CU_ASSERT_DOUBLE_EQUAL(nd_box_ratio(&covering, &touch, 3), 0.0, 1e-12);
+}
+
+int
+main(void)
+{
+	CU_pSuite suite;
+	unsigned int failures = 0;
+	if (CU_initialize_registry() != CUE_SUCCESS)
+		return CU_get_error();
+
+	suite = CU_add_suite("gserialized_histogram_helpers", NULL, NULL);
+	if (!suite)
+		goto cleanup;
+
+	if (!CU_add_test(suite, "histogram budget clamps", histogram_budget_clamps) ||
+	    !CU_add_test(suite, "nd_stats value index guards", nd_stats_indexing_behaviour) ||
+	    !CU_add_test(suite, "nd_box ratio edge cases", nd_box_ratio_cases))
+	{
+		goto cleanup;
+	}
+
+	CU_basic_set_mode(CU_BRM_VERBOSE);
+	CU_basic_run_tests();
+
+cleanup:
+	failures = CU_get_number_of_tests_failed();
+	CU_cleanup_registry();
+	return failures == 0 ? CUE_SUCCESS : 1;
+}

--- a/postgis/gserialized_estimate_support.h
+++ b/postgis/gserialized_estimate_support.h
@@ -1,0 +1,197 @@
+/**********************************************************************
+ *
+ * PostGIS - Spatial Types for PostgreSQL
+ * http://postgis.net
+ *
+ * This file is part of PostGIS
+ *
+ * PostGIS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * PostGIS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PostGIS.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **********************************************************************
+ *
+ * Internal helpers shared between the gserialized selectivity
+ * implementation and the unit tests.
+ *
+ * Keeping the routines header-only ensures the planner code and the
+ * harness evaluate the exact same floating-point flows without the
+ * cross-object plumbing that previously complicated maintenance.
+ * Nothing here is installed; the header is meant for
+ * gserialized_estimate.c and for the dedicated CUnit suite only.
+ *
+ **********************************************************************
+ *
+ * Copyright 2012 (C) Paul Ramsey <pramsey@cleverelephant.ca>
+ * Copyright 2025 (C) Darafei Praliaskouski <me@komzpa.net>
+ *
+ **********************************************************************/
+
+#ifndef POSTGIS_GSERIALIZED_ESTIMATE_SUPPORT_H
+#define POSTGIS_GSERIALIZED_ESTIMATE_SUPPORT_H
+
+#include "postgres.h"
+
+#include <limits.h>
+#include <math.h>
+
+/* The maximum number of dimensions our statistics code supports. */
+#define ND_DIMS 4
+
+/* Lightweight n-dimensional box representation for selectivity math. */
+typedef struct ND_BOX_T {
+	float4 min[ND_DIMS];
+	float4 max[ND_DIMS];
+} ND_BOX;
+
+/* Integer counterpart used for histogram cell iteration. */
+typedef struct ND_IBOX_T {
+	int min[ND_DIMS];
+	int max[ND_DIMS];
+} ND_IBOX;
+
+/* On-disk representation of the histogram emitted by ANALYZE. */
+typedef struct ND_STATS_T {
+	float4 ndims;
+	float4 size[ND_DIMS];
+	ND_BOX extent;
+	float4 table_features;
+	float4 sample_features;
+	float4 not_null_features;
+	float4 histogram_features;
+	float4 histogram_cells;
+	float4 cells_covered;
+	float4 value[1];
+} ND_STATS;
+
+/*
+ * Return the flattened index for the histogram coordinate expressed by
+ * 'indexes'.  A negative result signals that one of the axes fell outside
+ * the histogram definition.
+ */
+static inline int
+nd_stats_value_index(const ND_STATS *stats, const int *indexes)
+{
+	int d;
+	int accum = 1;
+	int vdx = 0;
+
+	for (d = 0; d < (int)(stats->ndims); d++)
+	{
+		int size = (int)(stats->size[d]);
+		if (indexes[d] < 0 || indexes[d] >= size)
+			return -1;
+		vdx += indexes[d] * accum;
+		accum *= size;
+	}
+	return vdx;
+}
+
+/*
+ * Derive the histogram grid budget requested by PostgreSQL's ANALYZE machinery.
+ * The planner caps the cell count via three heuristics that take the requested
+ * attstattarget, the histogram dimensionality, and the underlying row count
+ * into account.  Double precision arithmetic keeps the intermediate products in
+ * range so the cap behaves consistently across build architectures.
+ */
+static inline int
+histogram_cell_budget(double total_rows, int ndims, int attstattarget)
+{
+	double budget;
+	double dims_cap;
+	double rows_cap;
+	double attstat;
+	double dims;
+
+	if (ndims <= 0)
+		return 0;
+
+	if (attstattarget <= 0)
+		attstattarget = 1;
+
+	/* Requested resolution coming from PostgreSQL's ANALYZE knob. */
+	attstat = (double)attstattarget;
+	dims = (double)ndims;
+	budget = pow(attstat, dims);
+
+	/* Hard ceiling that keeps the statistics collector responsive. */
+	dims_cap = (double)ndims * 100000.0;
+	if (budget > dims_cap)
+		budget = dims_cap;
+
+	/* Small relations do not need a histogram that dwarfs the sample. */
+	if (total_rows <= 0.0)
+		return 0;
+
+	rows_cap = 10.0 * (double)ndims * total_rows;
+	if (rows_cap < 0.0)
+		rows_cap = 0.0;
+
+	/* Keep intermediate computations in double precision before clamping. */
+	if (rows_cap > (double)INT_MAX)
+		rows_cap = (double)INT_MAX;
+
+	if (budget > rows_cap)
+		budget = rows_cap;
+
+	if (budget >= (double)INT_MAX)
+		return INT_MAX;
+	if (budget <= 0.0)
+		return 0;
+
+	return (int)budget;
+}
+
+/*
+ * Compute the portion of 'target' covered by 'cover'.  The caller supplies the
+ * dimensionality because ND_BOX always carries four slots.  Degenerate volumes
+ * fold to zero, allowing the callers to detect slabs that ANALYZE sometimes
+ * emits for skewed datasets.
+ */
+static inline double
+nd_box_ratio(const ND_BOX *cover, const ND_BOX *target, int ndims)
+{
+	int d;
+	bool fully_covered = true;
+	double ivol = 1.0;
+	double refvol = 1.0;
+
+	for (d = 0; d < ndims; d++)
+	{
+		if (cover->max[d] <= target->min[d] || cover->min[d] >= target->max[d])
+			return 0.0; /* Disjoint */
+
+		if (cover->min[d] > target->min[d] || cover->max[d] < target->max[d])
+			fully_covered = false;
+	}
+
+	if (fully_covered)
+		return 1.0;
+
+	for (d = 0; d < ndims; d++)
+	{
+		double width = target->max[d] - target->min[d];
+		double imin = Max(cover->min[d], target->min[d]);
+		double imax = Min(cover->max[d], target->max[d]);
+		double iwidth = Max(0.0, imax - imin);
+
+		refvol *= width;
+		ivol *= iwidth;
+	}
+
+	if (refvol == 0.0)
+		return refvol;
+
+	return ivol / refvol;
+}
+
+#endif /* POSTGIS_GSERIALIZED_ESTIMATE_SUPPORT_H */


### PR DESCRIPTION
## Summary
- inline the histogram helper routines into a private header and document their numerical behaviour for reuse by planner code and tests
- update gserialized_estimate and its CUnit harness to include the new header while simplifying the build glue
- broaden the gserialized selectivity CUnit coverage with additional boundary checks for histogram sizing and nd_box overlap ratios

## Testing
- ./configure
- make -s -j$(nproc)
- make -C postgis/cunit check

------
https://chatgpt.com/codex/tasks/task_e_690107433ea8832491e721018d6f2738